### PR TITLE
Use the correct name for the custom device in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ Branch rebasing and other history modifications will be listed here, with severa
 
 ## License
 
-The Routing and Faulting Custom Device is licensed under an MIT-style license (see LICENSE). Other incorporated projects may be licensed under different licenses. All licenses allow for non-commercial and commercial use.
+The Embedded Data Logger Custom Device is licensed under an MIT-style license (see LICENSE). Other incorporated projects may be licensed under different licenses. All licenses allow for non-commercial and commercial use.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-embedded-data-logger-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fixes a small error in the README.md where the incorrect custom device name is used.

### Why should this Pull Request be merged?
It corrects a mistake.

### What testing has been done?
Looked at README.md in my own branch on github.