### PR TITLE
Add VeriStand as an nipkg dependency

### DIFF
--- a/control
+++ b/control
@@ -12,3 +12,4 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI Embedded Data Logger for VeriStand {veristand_version}
+Depends: {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-embedded-data-logger-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add the corresponding VeriStand version as an nipkg dependency.

### Why should this Pull Request be merged?

This prevents installing the custom device without the corresponding version of VeriStand being installed.

### What testing has been done?

None, but tested with the same change on another custom device.