### PR TITLE
Remove Pharlap and Linux ARM from custom device XML

### DIFF
--- a/Source/Custom Device Embedded Data Logger.xml
+++ b/Source/Custom Device Embedded Data Logger.xml
@@ -27,22 +27,6 @@
 				<RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\National Instruments\Embedded Data Logger\Embedded Data Logger Engine Windows.llb\RT Driver VI.vi</RealTimeSystemDestination>
 			</Source>
 			<Source>
-				<SupportedTarget>Pharlap</SupportedTarget>
-				<Source>
-					<Type>To Common Doc Dir</Type>
-					<Path>Custom Devices\National Instruments\Embedded Data Logger\PharLap\Embedded Data Logger Engine Pharlap.llb\RT Driver VI.vi</Path>
-				</Source>
-				<RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\National Instruments\Embedded Data Logger\Embedded Data Logger Engine Pharlap.llb\RT Driver VI.vi</RealTimeSystemDestination>
-			</Source>
-			<Source>
-				<SupportedTarget>Linux_32_ARM</SupportedTarget>
-				<Source>
-					<Type>To Common Doc Dir</Type>
-					<Path>Custom Devices\National Instruments\Embedded Data Logger\Linux_32_ARM\Embedded Data Logger Engine LinuxARM.llb\RT Driver VI.vi</Path>
-				</Source>
-				<RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\National Instruments\Embedded Data Logger\Embedded Data Logger Engine LinuxARM.llb\RT Driver VI.vi</RealTimeSystemDestination>
-			</Source>
-			<Source>
 				<SupportedTarget>Linux_x64</SupportedTarget>
 				<Source>
 					<Type>To Common Doc Dir</Type>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-embedded-data-logger-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fixes #46 

### Why should this Pull Request be merged?

The next release of this custom device will not support Pharlap or Linux ARM. #45 dropped builds for these operating systems, but the custom device XML needs to remove these references too.

### What testing has been done?

None
