### PR TITLE
Fix nipkg being empty

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -27,7 +27,7 @@ build_spec = 'Scripting API'
 
 [package]
 type = 'nipkg'
-payload_dir = 'Built'
+package_output_dir = 'Built'
 
 [package.payload_map]
 'Built\\Embedded Data Logger' = 'documents\National Instruments\NI VeriStand {veristand_version}\Custom Devices\National Instruments\Embedded Data Logger'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-embedded-data-logger-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fix a typo which resulted in the generated nipkg being empty.

### Why should this Pull Request be merged?

The nipkg is currently broken.

### What testing has been done?

Validated that the PR build generated a non-empty package.
