### PR TITLE
Allow copy/pasting log files and channel groups

### DIFF
--- a/Source/Custom Device Embedded Data Logger.xml
+++ b/Source/Custom Device Embedded Data Logger.xml
@@ -237,6 +237,7 @@
 				<eng>File Page</eng>
 				<loc>File Page</loc>
 			</Name>
+			<Copy>Copy</Copy>
 			<GUID>29edb790-3e4e-4121-9b93-a3d0540ab92c</GUID>
 			<Glyph>
 				<Type>To Common Doc Dir</Type>
@@ -270,6 +271,7 @@
 				<eng>Channel Group Page</eng>
 				<loc>Channel Group Page</loc>
 			</Name>
+			<Copy>Copy</Copy>
 			<GUID>6f0afb90-3eee-463c-9817-5273ea7ccf5e</GUID>
 			<Glyph>
 				<Type>To Common Doc Dir</Type>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-embedded-data-logger-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Allow copy/pasting the log file and channel groups sections of the custom device in System Explorer.

### Why should this Pull Request be merged?

This makes it easier to duplicate existing log configurations.

### What testing has been done?

Hand testing in VeriStand. Confirmed I could duplicate both log files and channel groups, and that the resulting system definition still logged data correctly on Windows.